### PR TITLE
Some updates for new CDS beta backend API

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - cdsapi >=0.5.1
+  - cdsapi >=0.7.0
   - jsonschema >=3.2.0
   - numpy >=1.17
   - python-dateutil >=2.8.1

--- a/test/test_era5.py
+++ b/test/test_era5.py
@@ -186,6 +186,9 @@ class CDSEra5Test(unittest.TestCase):
         self.assertEqual(361, len(dataset.variables["lon"]))
 
     def test_open_data_null_variables_list(self):
+        # As of 2024-07-26, fails with new CDS beta API, because it returns
+        # a Zip rather than a NetCDF for this particular parameter set.
+
         store = CDSDataStore(
             client_class=get_cds_client(),
             endpoint_url=_CDS_API_URL,

--- a/xcube_cds/datasets/reanalysis_era5.py
+++ b/xcube_cds/datasets/reanalysis_era5.py
@@ -43,8 +43,17 @@ from xcube_cds.store import CDSDatasetHandler
 
 
 class ERA5DatasetHandler(CDSDatasetHandler):
-    def __init__(self):
+
+    def __init__(self, api_version: int = 1):
+        """Instantiate a new ERA5 dataset handler
+
+        :param api_version: the API version to use when interfacing with the
+            backend CDS service. 1 indicates the original API version used
+            at launch. 2 indicates the new version introduced in 2024.
+        """
         self._read_dataset_info()
+        assert(api_version in {1, 2})
+        self._api_version = api_version
 
     def _read_dataset_info(self):
         """Read dataset information from JSON files"""
@@ -292,7 +301,8 @@ class ERA5DatasetHandler(CDSDatasetHandler):
             # but is described at
             # https://confluence.ecmwf.int/display/CKB/ERA5%3A+Web+API+to+CDS+API
             "grid": [resolution, resolution],
-            "format": "netcdf",
+            # API versions 1 and 2 use different keys for format specifier.
+            {1: "format", 2: "data_format"}[self._api_version]: "netcdf",
         }
 
         if product_type is not None:

--- a/xcube_cds/store.py
+++ b/xcube_cds/store.py
@@ -688,7 +688,16 @@ class CDSDataOpener(DataOpener):
         # dataset = dataset.rename_vars({'longitude': 'lon', 'latitude': 'lat'})
         # dataset.transpose('time', ..., 'lat', 'lon')
 
+        # With the new CDS backend introduced in 2024, the ERA5 time coordinate
+        # is called "valid_time" rather than "time".
+        if "valid_time" in dataset.coords and "time" not in dataset.coords:
+            dataset = dataset.rename({"valid_time": "time"})
+
+        # This assignment also conveniently asserts the expected presence of
+        # a time coordinate. This is a good place to fail if time is absent
+        # (e.g. due to a change in backend behaviour).
         dataset.coords["time"].attrs["standard_name"] = "time"
+
         # Correct units not entirely clear: cubespec document says
         # degrees_north / degrees_east for WGS84 Schema, but SH Plugin
         # had decimal_degrees.


### PR DESCRIPTION
These changes don't yet provide full support for the new API version (in part because the API server is in beta and it's not yet clear whether some of its new behaviours are planned changes or temporary bugs), but with them applied all but one of the unit tests pass. test_open_data_null_variables_list fails because the API server returns a Zip rather than the requested NetCDF.

- Require cdsapi >=0.7.0

- Add an api_version parameter to ERA5DatasetHandler.__init__ (defaulting to 1).

- Support new `data_format` parameter (replaces old `format`) in ERA5DatasetHandler

- In CDSDataOpener, support both old and new ERA5 time coordinate names (`time` and `valid_time` respectively).